### PR TITLE
Add basic unit tests

### DIFF
--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/Tests/SundayTests/VitaminDCalculatorTests.swift
+++ b/Tests/SundayTests/VitaminDCalculatorTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Sunday
+
+final class VitaminDCalculatorTests: XCTestCase {
+    func testClothingExposureFactor() {
+        XCTAssertEqual(ClothingLevel.none.exposureFactor, 1.0)
+        XCTAssertEqual(ClothingLevel.heavy.exposureFactor, 0.10, accuracy: 0.0001)
+    }
+
+    func testSunscreenTransmissionFactor() {
+        XCTAssertEqual(SunscreenLevel.spf30.uvTransmissionFactor, 0.03, accuracy: 0.0001)
+        XCTAssertEqual(SunscreenLevel.spf100.uvTransmissionFactor, 0.01, accuracy: 0.0001)
+    }
+
+    func testSkinTypeVitaminDFactor() {
+        XCTAssertEqual(SkinType.type1.vitaminDFactor, 1.25, accuracy: 0.0001)
+        XCTAssertEqual(SkinType.type6.vitaminDFactor, 0.2, accuracy: 0.0001)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -87,3 +87,13 @@ targets:
           enabled: true
           groups:
             - group.sunday.widget
+
+  SundayTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - Tests/SundayTests
+    info:
+      path: Tests/Info.plist
+    dependencies:
+      - target: Sunday


### PR DESCRIPTION
## Summary
- add unit test target configuration
- add vitamin D calculator factor tests

## Testing
- `swift test 2>&1 | head -n 20`
- `xcodebuild test -scheme Sunday 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689871d13a008327ac657d5f8f9f103d